### PR TITLE
bugfix/accurics_remediation_0043242042529152425 - Auto Generated Pull Request From Accurics

### DIFF
--- a/azure/storage_container.tf
+++ b/azure/storage_container.tf
@@ -11,5 +11,5 @@ resource "azurerm_storage_account" "tenable_cs_demo_storage_account" {
 resource "azurerm_storage_container" "tenable_cs_demo_storage_container" {
   name                  = "tenablecsdemostorctnr"
   storage_account_name  = azurerm_storage_account.tenable_cs_demo_storage_account.name
-  container_access_type = "blob"
+  container_access_type = "private"
 }


### PR DESCRIPTION
Set 'container_access_type' to 'private' to ensure Azure Storage Account Container can only be used by authorized clients.