### PR TITLE
bugfix/accurics_remediation_1347247690029285 - Auto Generated Pull Request From Accurics

### DIFF
--- a/azure/security_group.tf
+++ b/azure/security_group.tf
@@ -13,7 +13,7 @@ resource "azurerm_network_security_rule" "ssh_security_rule" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefix       = "0.0.0.0/0"
+  source_address_prefix       = "<cidr>"
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.tenable_cs_demo_rg.name
   network_security_group_name = azurerm_network_security_group.tenable_cs_demo_sg_ssh.name


### PR DESCRIPTION
Configure Network Security Rule for port 22 to ensure it is not exposed to entire internet. In console -
1. In settings of NSG select Inbound security rules.
2. Use Add button here to add security rules.
3. Create security rules for any application, port range, ip range.
In terraform -
Set the value of 'access' to [allow | deny]. Set the value of 'direction' to 'inbound'. Set the value of 'source_address_prefix' to an IP address or a range of IP addresses. These network security rules in controlling inbound connections to your resources in Azure.